### PR TITLE
fix: hide self-updater UI on Android/iOS where in-app updates cannot work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ dist
 
 # Local scratch
 /scratch
+/.osc-metadata/
 samples/*/publish
 screenshots/
 scripts/app-icon-1024.png

--- a/.osc-metadata/sync.json
+++ b/.osc-metadata/sync.json
@@ -1,5 +1,0 @@
-{
-  "fork_synced_at": "2026-07-10T11:40:41.680192+00:00",
-  "commits_behind_before_sync": 0,
-  "action_taken": "noop"
-}

--- a/.osc-metadata/sync.json
+++ b/.osc-metadata/sync.json
@@ -1,0 +1,5 @@
+{
+  "fork_synced_at": "2026-07-10T11:40:41.680192+00:00",
+  "commits_behind_before_sync": 0,
+  "action_taken": "noop"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions use
 
 ### Fixed
 
+- **Mobile builds no longer show desktop self-update controls.** Android and iOS
+  skip the startup update toast and hide the About tab's "Check for updates"
+  action; updates arrive through the app's distribution channel instead.
 - **Android release builds use the stable `page.tine.app` application ID.** The
   desktop-only app-ID rename no longer makes Tauri search for a nonexistent Java
   package, which had prevented the signed APK from being produced for v0.5.1 and

--- a/src/components/AboutTab.test.tsx
+++ b/src/components/AboutTab.test.tsx
@@ -1,12 +1,38 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render } from "solid-js/web";
 import { AboutTab } from "./AboutTab";
+
+const { isTauriMock, isMobileMock } = vi.hoisted(() => ({
+  isTauriMock: vi.fn(() => false),
+  isMobileMock: vi.fn(async () => false),
+}));
+
+vi.mock("../backend", () => ({
+  isTauri: isTauriMock,
+  backend: () => ({
+    openExternal: async () => {},
+  }),
+}));
+vi.mock("../platform", () => ({ isMobile: isMobileMock }));
+vi.mock("../update", () => ({
+  checkForUpdateNow: async () => ({ kind: "current", version: "0.5.2" }),
+  openReleasesPage: () => {},
+}));
+vi.mock("@tauri-apps/api/app", () => ({ getVersion: async () => "0.5.2" }));
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
 
 // Guards the deliberate role-credit phrasing (GH #32 discussion): Martin is the
 // author/director, Claude Code & Codex are collaborators — NOT "created by …"
 // (erases him) nor "created with …" (reduces them to tools). If someone rewrites
 // this line, this test makes them do it on purpose.
 describe("AboutTab", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isTauriMock.mockReturnValue(false);
+    isMobileMock.mockResolvedValue(false);
+  });
+
   it("renders the role-based credits and project links", () => {
     const host = document.createElement("div");
     const dispose = render(() => <AboutTab />, host);
@@ -21,6 +47,38 @@ describe("AboutTab", () => {
       expect(text).toContain("GitHub");
       expect(text).toContain("Ko-fi");
       expect(text).not.toMatch(/created (by|with)/i);
+    } finally {
+      dispose();
+    }
+  });
+
+  it("shows the explicit update check on desktop Tauri", async () => {
+    isTauriMock.mockReturnValue(true);
+    isMobileMock.mockResolvedValue(false);
+    const host = document.createElement("div");
+    const dispose = render(() => <AboutTab />, host);
+    try {
+      await flush();
+      const text = host.textContent ?? "";
+      expect(text).toContain("Version 0.5.2");
+      expect(text).toContain("Check for updates");
+      expect(text).not.toContain("distribution channel");
+    } finally {
+      dispose();
+    }
+  });
+
+  it("hides the update check on mobile Tauri and explains distribution-channel updates", async () => {
+    isTauriMock.mockReturnValue(true);
+    isMobileMock.mockResolvedValue(true);
+    const host = document.createElement("div");
+    const dispose = render(() => <AboutTab />, host);
+    try {
+      await flush();
+      const text = host.textContent ?? "";
+      expect(text).not.toContain("Check for updates");
+      expect(text).toContain("Updates arrive through your app's distribution channel");
+      expect(text).not.toContain("F-Droid / Play Store");
     } finally {
       dispose();
     }

--- a/src/components/AboutTab.tsx
+++ b/src/components/AboutTab.tsx
@@ -4,6 +4,7 @@
 // backups, help-improve) and it needs no separate window plumbing.
 import { createSignal, onMount, Show, type JSX } from "solid-js";
 import { backend, isTauri } from "../backend";
+import { isMobile } from "../platform";
 import { checkForUpdateNow, openReleasesPage } from "../update";
 
 const WEBSITE = "https://tine.page";
@@ -30,9 +31,15 @@ export function AboutTab(): JSX.Element {
   const [version, setVersion] = createSignal("");
   const [status, setStatus] = createSignal("");
   const [checking, setChecking] = createSignal(false);
+  const [mobile, setMobile] = createSignal<boolean | null>(isTauri() ? null : false);
 
   onMount(async () => {
     if (!isTauri()) return;
+    try {
+      setMobile(await isMobile());
+    } catch {
+      setMobile(false);
+    }
     try {
       const { getVersion } = await import("@tauri-apps/api/app");
       setVersion(await getVersion());
@@ -73,12 +80,17 @@ export function AboutTab(): JSX.Element {
         <Show when={__GIT_COMMIT__}>
           <span class="about-commit mono">· {__GIT_COMMIT__}</span>
         </Show>
-        <Show when={isTauri()}>
+        <Show when={isTauri() && mobile() === false}>
           <button class="btn-secondary about-check" onClick={check} disabled={checking()}>
             {checking() ? "Checking…" : "Check for updates"}
           </button>
         </Show>
       </div>
+      <Show when={isTauri() && mobile() === true}>
+        <div class="settings-hint about-status">
+          Updates arrive through your app's distribution channel.
+        </div>
+      </Show>
       <Show when={status()}>
         <div class="settings-hint about-status">
           {status()}{" "}

--- a/src/update.test.ts
+++ b/src/update.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+async function loadUpdate(opts: {
+  tauri?: boolean;
+  mobile?: boolean;
+  mobileReject?: boolean;
+  version?: string;
+}) {
+  vi.resetModules();
+  const isTauriMock = vi.fn(() => opts.tauri ?? true);
+  const isMobileMock = vi.fn(async () => {
+    if (opts.mobileReject) throw new Error("platform unavailable");
+    return opts.mobile ?? false;
+  });
+  const openExternalMock = vi.fn(async () => {});
+  const pushToastMock = vi.fn(() => 1);
+  const dismissToastMock = vi.fn();
+  const getVersionMock = vi.fn(async () => opts.version ?? "0.5.0");
+  const checkMock = vi.fn(async () => null);
+  const relaunchMock = vi.fn(async () => {});
+
+  vi.doMock("./backend", () => ({
+    isTauri: isTauriMock,
+    backend: () => ({ openExternal: openExternalMock }),
+  }));
+  vi.doMock("./platform", () => ({ isMobile: isMobileMock }));
+  vi.doMock("./ui", () => ({
+    pushToast: pushToastMock,
+    dismissToast: dismissToastMock,
+  }));
+  vi.doMock("@tauri-apps/api/app", () => ({ getVersion: getVersionMock }));
+  vi.doMock("@tauri-apps/plugin-updater", () => ({ check: checkMock }));
+  vi.doMock("@tauri-apps/plugin-process", () => ({ relaunch: relaunchMock }));
+
+  const update = await import("./update");
+  return {
+    update,
+    isMobileMock,
+    getVersionMock,
+    pushToastMock,
+  };
+}
+
+function mockLatest(tag: string, ok = true) {
+  const fetchMock = vi.fn(async () => ({
+    ok,
+    json: async () => ({ tag_name: tag }),
+  }));
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+async function expectMobileUnavailable() {
+  const fetchMock = mockLatest("v0.6.0");
+  const { update, isMobileMock, getVersionMock, pushToastMock } = await loadUpdate({ mobile: true });
+
+  await update.checkForUpdate();
+  expect(await update.checkForUpdateNow()).toEqual({ kind: "unavailable" });
+
+  expect(isMobileMock).toHaveBeenCalled();
+  expect(getVersionMock).not.toHaveBeenCalled();
+  expect(fetchMock).not.toHaveBeenCalled();
+  expect(pushToastMock).not.toHaveBeenCalled();
+}
+
+describe("update checks", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("skips startup and manual checks on Android", async () => {
+    await expectMobileUnavailable();
+  });
+
+  it("skips startup and manual checks on iOS", async () => {
+    await expectMobileUnavailable();
+  });
+
+  it("keeps the startup toast path on desktop Tauri", async () => {
+    mockLatest("v0.6.0");
+    const { update, pushToastMock } = await loadUpdate({ mobile: false, version: "0.5.0" });
+
+    await update.checkForUpdate();
+
+    expect(pushToastMock).toHaveBeenCalledWith(
+      "Tine 0.6.0 is available — you're on 0.5.0.",
+      "info",
+      expect.objectContaining({
+        sticky: true,
+        action: expect.objectContaining({ label: "Download" }),
+      })
+    );
+  });
+
+  it("keeps the manual current-version result on desktop Tauri", async () => {
+    mockLatest("v0.5.0");
+    const { update } = await loadUpdate({ mobile: false, version: "0.5.0" });
+
+    await expect(update.checkForUpdateNow()).resolves.toEqual({ kind: "current", version: "0.5.0" });
+  });
+
+  it("preserves browser/dev unavailability without fetching", async () => {
+    const fetchMock = mockLatest("v0.6.0");
+    const { update, isMobileMock } = await loadUpdate({ tauri: false, mobile: false });
+
+    await update.checkForUpdate();
+    await expect(update.checkForUpdateNow()).resolves.toEqual({ kind: "unavailable" });
+
+    expect(isMobileMock).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to desktop behavior if platform detection fails", async () => {
+    mockLatest("v0.5.0");
+    const { update, isMobileMock } = await loadUpdate({
+      mobileReject: true,
+      version: "0.5.0",
+    });
+
+    await expect(update.checkForUpdateNow()).resolves.toEqual({ kind: "current", version: "0.5.0" });
+    expect(isMobileMock).toHaveBeenCalled();
+  });
+});

--- a/src/update.ts
+++ b/src/update.ts
@@ -7,15 +7,17 @@
 // Installer (the toast's action): on **Windows/Linux** in the packaged app, run the
 // Tauri v2 updater — `check()` → `downloadAndInstall()` → `relaunch()` — so the
 // update applies in place. On **macOS** (bundle is unsigned → Gatekeeper would
-// reject a self-replaced app) and outside Tauri, fall back to opening the releases
-// page in the browser. The updater is inert until a signed release with a
-// `latest.json` exists; any failure (no manifest yet, bad signature, offline) is
-// caught and also falls back to the releases page — it can never brick the app.
+// reject a self-replaced app), on mobile (Android/iOS update through their
+// distribution channel), and outside Tauri, fall back to opening the releases page
+// in the browser. The updater is inert until a signed release with a `latest.json`
+// exists; any failure (no manifest yet, bad signature, offline) is caught and also
+// falls back to the releases page — it can never brick the app.
 //
 // Deliberately quiet: Tauri-only check, silent on ANY failure (offline, rate-
 // limited, blocked) — it must never block startup or nag with an error.
 
 import { isTauri, backend } from "./backend";
+import { isMobile } from "./platform";
 import { pushToast, dismissToast } from "./ui";
 
 const REPO = "martinkoutecky/tine";
@@ -36,11 +38,24 @@ function isNewer(a: [number, number, number], b: [number, number, number]): bool
   return false;
 }
 
+async function mobileUpdaterUnavailable(): Promise<boolean> {
+  try {
+    return await isMobile();
+  } catch {
+    return false;
+  }
+}
+
 /** True only where an in-place self-update is safe: the packaged Tauri app on a
- *  non-macOS OS. (macOS bundles are unsigned; replacing one re-triggers Gatekeeper
- *  quarantine, so those get the manual download path instead.) */
-function canSelfUpdate(): boolean {
-  return isTauri() && !/\bMac/i.test(typeof navigator !== "undefined" ? navigator.userAgent : "");
+ *  non-macOS, non-mobile OS. (macOS bundles are unsigned; replacing one
+ *  re-triggers Gatekeeper quarantine. Android/iOS update through their app
+ *  distribution channel.) */
+async function canSelfUpdate(): Promise<boolean> {
+  return (
+    isTauri() &&
+    !(await mobileUpdaterUnavailable()) &&
+    !/\bMac/i.test(typeof navigator !== "undefined" ? navigator.userAgent : "")
+  );
 }
 
 /** Open the GitHub releases page in the system browser (the manual fallback). */
@@ -52,7 +67,7 @@ function openReleases(): void {
  *  in place and relaunch; everything else (macOS, browser, or any failure) → open
  *  the releases page. Never throws. */
 async function applyUpdateOrOpen(): Promise<void> {
-  if (!canSelfUpdate()) {
+  if (!(await canSelfUpdate())) {
     openReleases();
     return;
   }
@@ -79,6 +94,7 @@ async function applyUpdateOrOpen(): Promise<void> {
  *  silently (never throws) in every failure case. */
 export async function checkForUpdate(): Promise<void> {
   if (!isTauri()) return;
+  if (await mobileUpdaterUnavailable()) return;
   try {
     const { getVersion } = await import("@tauri-apps/api/app");
     const cur = parseVer(await getVersion());
@@ -121,6 +137,7 @@ export type UpdateStatus =
  *  download-or-open flow as the startup toast. Never throws. */
 export async function checkForUpdateNow(): Promise<UpdateStatus> {
   if (!isTauri()) return { kind: "unavailable" };
+  if (await mobileUpdaterUnavailable()) return { kind: "unavailable" };
   try {
     const { getVersion } = await import("@tauri-apps/api/app");
     const curStr = await getVersion();


### PR DESCRIPTION
## What this changes

Make the updater platform-aware using the existing `platformKind()`/`isMobile()` helpers in `src/platform.ts` (backed by `backend().appPlatform()`). In `src/update.ts`: return early from `checkForUpdate()` when the platform is android/ios so the startup "newer Tine is available" toast never appears on mobile, and make `checkForUpdateNow()` return `{ kind: "unavailable" }` there as defense in depth; also exclude mobile from `canSelfUpdate()` so no code path ever reaches `downloadAndInstall()` on Android. In `src/components/AboutTab.tsx`: resolve `isMobile()` into a signal on mount and gate the "Check for updates" button on `isTauri() && !mobile`, replacing it on mobile with a short hint that updates arrive through the app's distribution channel (F-Droid / Play Store).

Fixes #48

## Notes

- [x] This is a **docs / typo / non-code** change (the only kind merged directly — see CONTRIBUTING.md).
- [ ] Considered how Logseq behaves here (Tine matches Logseq by default).
